### PR TITLE
Use Hadamard matrix directly in `setup_reconstruction`

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ model_root = '../models/'
 
 import spyrit.misc.walsh_hadamard as wh
 H = wh.walsh2_matrix(64)/64        
-model, device = setup_reconstruction(cov_path, mean_path, '../stats/H.npy', model_root, network_params)
+model, device = setup_reconstruction(cov_path, mean_path, H, model_root, network_params)
 ```
 
 Load noise calibration parameters (provided with the data or computed using tools in `/noise-calibration`):

--- a/scripts/acquisition-recon-multiprocessing.py
+++ b/scripts/acquisition-recon-multiprocessing.py
@@ -3,7 +3,7 @@ Example of an acquisition of 1/4 of the Hadamard patterns and then performs a
 reconstruction using 1/4 of the patterns  a DenoiCompNet model and a noise model
 in "real-time", using multiprocessing.
 """
-
+import spyrit.misc.walsh_hadamard as wh
 from spas import *
 
 if __name__ == '__main__':
@@ -53,10 +53,10 @@ if __name__ == '__main__':
         
     cov_path = './...'
     mean_path = './...'
-    H_path = './...'
+    H = wh.walsh2_matrix(64)/64
     model_root = './...'
         
-    model, device = setup_reconstruction(cov_path, mean_path, H_path, model_root, network_params)
+    model, device = setup_reconstruction(cov_path, mean_path, H, model_root, network_params)
     noise = load_noise('../noise-calibration/fit_model.npz')
     
     reconstruction_params = {

--- a/scripts/acquisition-recon-sequential.py
+++ b/scripts/acquisition-recon-sequential.py
@@ -57,10 +57,10 @@ network_params = ReconstructionParameters(
         
 cov_path = '../stats/Cov_64x64.npy'
 mean_path = '../stats/Average_64x64.npy'
-H_path = '../stats/H.npy'
+H = wh.walsh2_matrix(64)/64
 model_root = '../models/'
         
-model, device = setup_reconstruction(cov_path, mean_path, H_path, model_root, network_params)
+model, device = setup_reconstruction(cov_path, mean_path, H, model_root, network_params)
 noise = load_noise('../noise-calibration/fit_model.npz')
 
 #%% Acquire

--- a/spas/reconstruction_nn.py
+++ b/spas/reconstruction_nn.py
@@ -67,7 +67,7 @@ class ReconstructionParameters:
         self._net_arch = int(netType[arch_name])
     
 
-def setup_reconstruction(cov_path: str, mean_path: str, H_path: str, 
+def setup_reconstruction(cov_path: str, mean_path: str, H: np.ndarray, 
     model_root: str, network_params: ReconstructionParameters
     ) -> Tuple[Union[compNet, noiCompNet, DenoiCompNet], str]:
     """Loads a neural network for reconstruction.
@@ -77,8 +77,8 @@ def setup_reconstruction(cov_path: str, mean_path: str, H_path: str,
             Path to the covariance matrix.
         mean_path (str): 
             Path to the mean matrix.
-        H_path (str): 
-            Path to the Hadamard matrix used for creating the acquired patterns.
+        H (nd.array): 
+            Hadamard matrix with patterns.
         model_root (str): 
             Folder containing trained models for reconstruction.
         network_params (ReconstructionParameters): 
@@ -99,8 +99,6 @@ def setup_reconstruction(cov_path: str, mean_path: str, H_path: str,
 
     Cov_had = np.load(cov_path)
     Mean_had = np.load(mean_path)
-
-    H = np.load(H_path)
 
     suffix = '_N_{}_M_{}_epo_{}_lr_{}_sss_{}_sdr_{}_bs_{}_reg_{}'.format(
            network_params.img_size, network_params.CR, 


### PR DESCRIPTION
`setup_reconstruction` won't receive the path to a Hadamard matrix saved in the disk anymore.